### PR TITLE
Added gnu99 standard, changed description to match

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,11 +1,9 @@
 #
-# makefile for color utilities C library
-# assumes cmocka (a unit testing framework) is installed on your
-# system
+# makefile for image utilities C library
 #
 
 CC = gcc
-FLAGS = -Wall
+FLAGS = -Wall --std=gnu99
 INCLUDES = -lm
 
 imageDriver: imageUtils.o imageDriver.c


### PR DESCRIPTION
Looks like the top of the file was copied from the previous hack, I made the appropriate changes to make sure it compiles with the new standard and so that the description is meaningful.